### PR TITLE
ci: stop sharing a checkout cache with other projects on the 'mozilla…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -207,7 +207,7 @@ tasks:
                                         ACTION_CALLBACK: '${action.cb_name}'
 
                           cache:
-                              "${trustDomain}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
+                              "${trustDomain}-project-${project}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
 
                           features:
                               taskclusterProxy: true


### PR DESCRIPTION
…' trust domain