### PR TITLE
chore: version bump to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+## 1.0.0 (2023-12-13)
+
+### Feat
+
+- add support for synchronous environments
+
+## 0.2.0 (2023-11-02)
+
+### Feat
+
+- add methods for 'PUT', 'PATCH' and 'DELETE' requests
+
+## 0.1.3 (2023-10-27)
+
+### Fix
+
+- ensure 'AppInstallationAuth' closes its internal client
+
+## 0.1.2 (2023-10-23)
+
+### Feat
+
+- rename 'client._make_request' to 'client.request'
+
+### Fix
+
+- stop using 'TypeAlias' to support older Pythons
+
+## 0.1.1 (2023-10-22)
+
+### Feat
+
+- implement Github client with authentication
+
+### Fix
+
+- use 'TypeAlias' for compatibility with older Pythons
+- don't assume responses are json
+
+### Refactor
+
+- use custom type for REST api responses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simple-github"
-version = "0.2.0"
+version = "1.0.0"
 description = "A simple Github client that only provides auth and access to the REST and GraphQL APIs."
 authors = ["Mozilla Release Engineering <release@mozilla.com>"]
 license = "MPL-2.0"


### PR DESCRIPTION
All the features I wanted to implement have been implemented, and this is being used in production by treescript. So I think now is a good time to release 1.0

This also adds a changelog generated by commitizen.