### PR TITLE
feat: forward kwargs to `request` method

### DIFF
--- a/src/simple_github/client.py
+++ b/src/simple_github/client.py
@@ -52,19 +52,27 @@ class Client:
     def request(self, method: str, query: str, **kwargs: Any) -> BaseResponse: ...
 
     @abstractmethod
-    def get(self, query: str) -> BaseResponse: ...
+    def get(self, query: str, **kwargs: Any) -> BaseResponse: ...
 
     @abstractmethod
-    def post(self, query: str, data: RequestData = None) -> BaseResponse: ...
+    def post(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> BaseResponse: ...
 
     @abstractmethod
-    def put(self, query: str, data: RequestData = None) -> BaseResponse: ...
+    def put(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> BaseResponse: ...
 
     @abstractmethod
-    def patch(self, query: str, data: RequestData = None) -> BaseResponse: ...
+    def patch(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> BaseResponse: ...
 
     @abstractmethod
-    def delete(self, query: str, data: RequestData = None) -> BaseNone: ...
+    def delete(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> BaseNone: ...
 
     @abstractmethod
     def execute(self, query: str, variables: RequestData = None) -> BaseDict: ...
@@ -140,7 +148,7 @@ class SyncClient(Client):
         with session.request(method, url, **kwargs) as resp:
             return resp
 
-    def get(self, query: str) -> RequestsResponse:
+    def get(self, query: str, **kwargs: Any) -> RequestsResponse:
         """Make a GET request to Github's REST API.
 
         Args:
@@ -149,9 +157,11 @@ class SyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return self.request("GET", query)
+        return self.request("GET", query, **kwargs)
 
-    def post(self, query: str, data: RequestData = None) -> RequestsResponse:
+    def post(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> RequestsResponse:
         """Make a POST request to Github's REST API.
 
         Args:
@@ -161,9 +171,11 @@ class SyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return self.request("POST", query, data=json.dumps(data))
+        return self.request("POST", query, data=json.dumps(data), **kwargs)
 
-    def put(self, query: str, data: RequestData = None) -> RequestsResponse:
+    def put(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> RequestsResponse:
         """Make a PUT request to Github's REST API.
 
         Args:
@@ -173,9 +185,11 @@ class SyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return self.request("PUT", query, data=json.dumps(data))
+        return self.request("PUT", query, data=json.dumps(data), **kwargs)
 
-    def patch(self, query: str, data: RequestData = None) -> RequestsResponse:
+    def patch(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> RequestsResponse:
         """Make a PATCH request to Github's REST API.
 
         Args:
@@ -185,16 +199,16 @@ class SyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return self.request("PATCH", query, data=json.dumps(data))
+        return self.request("PATCH", query, data=json.dumps(data), **kwargs)
 
-    def delete(self, query: str, data: RequestData = None) -> None:
+    def delete(self, query: str, data: RequestData = None, **kwargs: Any) -> None:
         """Make a DELETE request to Github's REST API.
 
         Args:
             query (str): The path segment of the request, e.g `/octocat`.
             data (Dict): The data to send in the request (optional).
         """
-        self.request("DELETE", query, data=json.dumps(data))
+        self.request("DELETE", query, data=json.dumps(data), **kwargs)
 
     def execute(self, query: str, variables: RequestData = None) -> Dict[str, Any]:
         """Execute a query against Github's GraphQL endpoint.
@@ -278,7 +292,7 @@ class AsyncClient(Client):
         session = await self._get_aiohttp_session()
         return await session.request(method, url, **kwargs)
 
-    async def get(self, query: str) -> ClientResponse:
+    async def get(self, query: str, **kwargs: Any) -> ClientResponse:
         """Make a GET request to Github's REST API.
 
         Args:
@@ -287,9 +301,11 @@ class AsyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return await self.request("GET", query)
+        return await self.request("GET", query, **kwargs)
 
-    async def post(self, query: str, data: RequestData = None) -> ClientResponse:
+    async def post(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> ClientResponse:
         """Make a POST request to Github's REST API.
 
         Args:
@@ -299,9 +315,11 @@ class AsyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return await self.request("POST", query, data=json.dumps(data))
+        return await self.request("POST", query, data=json.dumps(data), **kwargs)
 
-    async def put(self, query: str, data: RequestData = None) -> ClientResponse:
+    async def put(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> ClientResponse:
         """Make a PUT request to Github's REST API.
 
         Args:
@@ -311,9 +329,11 @@ class AsyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return await self.request("PUT", query, data=json.dumps(data))
+        return await self.request("PUT", query, data=json.dumps(data), **kwargs)
 
-    async def patch(self, query: str, data: RequestData = None) -> ClientResponse:
+    async def patch(
+        self, query: str, data: RequestData = None, **kwargs: Any
+    ) -> ClientResponse:
         """Make a PATCH request to Github's REST API.
 
         Args:
@@ -323,16 +343,16 @@ class AsyncClient(Client):
         Returns:
             Dict: The JSON result of the request.
         """
-        return await self.request("PATCH", query, data=json.dumps(data))
+        return await self.request("PATCH", query, data=json.dumps(data), **kwargs)
 
-    async def delete(self, query: str, data: RequestData = None) -> None:
+    async def delete(self, query: str, data: RequestData = None, **kwargs: Any) -> None:
         """Make a DELETE request to Github's REST API.
 
         Args:
             query (str): The path segment of the request, e.g `/octocat`.
             data (Dict): The data to send in the request (optional).
         """
-        await self.request("DELETE", query, data=json.dumps(data))
+        await self.request("DELETE", query, data=json.dumps(data), **kwargs)
 
     async def execute(
         self, query: str, variables: RequestData = None


### PR DESCRIPTION
This allows passing headers / other parameters to the underlying requests or aiohttp call.