### PR TITLE
fix: ensure ssl verification happens with async client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "aiohttp[speedups]~=3.8",
-  "gql[aiohttp,requests]~=3.4",
+  "gql[aiohttp,requests]>=3.5.1,<4",
   "pyjwt[crypto]~=2.8",
   "requests~=2.31",
 ]

--- a/src/simple_github/client.py
+++ b/src/simple_github/client.py
@@ -248,7 +248,9 @@ class AsyncClient(Client):
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        transport = AIOHTTPTransport(url=GITHUB_GRAPHQL_ENDPOINT, headers=headers, ssl=True)
+        transport = AIOHTTPTransport(
+            url=GITHUB_GRAPHQL_ENDPOINT, headers=headers, ssl=True
+        )
         self._gql_client = GqlClient(
             transport=transport, fetch_schema_from_transport=False
         )

--- a/src/simple_github/client.py
+++ b/src/simple_github/client.py
@@ -248,7 +248,7 @@ class AsyncClient(Client):
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        transport = AIOHTTPTransport(url=GITHUB_GRAPHQL_ENDPOINT, headers=headers)
+        transport = AIOHTTPTransport(url=GITHUB_GRAPHQL_ENDPOINT, headers=headers, ssl=True)
         self._gql_client = GqlClient(
             transport=transport, fetch_schema_from_transport=False
         )


### PR DESCRIPTION
gql recently had an issue reported where SSL connections are not verified by default: https://github.com/graphql-python/gql/issues/529

They're planning to make it the default behaviour in their next release, but we should ensure SSL verification happens in the meantime.