### PR TITLE
feat: add from_env client helper

### DIFF
--- a/src/simple_github/__init__.py
+++ b/src/simple_github/__init__.py
@@ -1,8 +1,25 @@
 import asyncio
+import os
+from functools import partial
 from typing import List, Optional, Union
 
 from .auth import AppAuth, AppInstallationAuth, PublicAuth, TokenAuth
 from .client import AsyncClient, Client, SyncClient
+
+
+def client_from_env(owner: str, repositories: list[str]):
+    if "GITHUB_TOKEN" in os.environ:
+        return partial(TokenClient, os.environ["GITHUB_TOKEN"])
+    elif "GITHUB_APP_ID" in os.environ and "GITHUB_APP_PRIVKEY" in os.environ:
+        return partial(
+            AppClient,
+            int(os.environ["GITHUB_APP_ID"]),
+            os.environ["GITHUB_APP_PRIVKEY"],
+            owner=owner,
+            repositories=repositories,
+        )
+    else:
+        return PublicClient
 
 
 def AppClient(


### PR DESCRIPTION
This centralizes a common way to support all client types.