### PR TITLE
ci: run on t-linux-docker-noscratch workers instead of t-linux-large-gcp

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -19,4 +19,4 @@ workers:
       provisioner: '{trust-domain}-t'
       implementation: docker-worker
       os: linux
-      worker-type: 't-{alias}-large-gcp'
+      worker-type: 't-{alias}-docker-noscratch'


### PR DESCRIPTION
Part of https://bugzilla.mozilla.org/show_bug.cgi?id=1922504