### PR TITLE
fix: stop declaring support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,7 @@ readme = "README.md"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3",
   "Topic :: Software Development",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
Follow up from https://github.com/mozilla-releng/simple-github/pull/101, which actually dropped support for it.