### PR TITLE
bug(auth): don't fail on missing `login` in app installation details

### DIFF
--- a/src/simple_github/auth.py
+++ b/src/simple_github/auth.py
@@ -144,7 +144,7 @@ class AppInstallationAuth(Auth):
         assert isinstance(installations, list)
 
         for installation in installations:
-            if installation["account"]["login"] == self.owner:
+            if installation["account"].get("login") == self.owner:
                 return installation["id"]
 
         raise Exception(


### PR DESCRIPTION
Apps can be installed in enterprises, which don't have a `login`, but a `slug` field.

By using `get` here, we protect against `KeyError`s in case some installations are for enterprises.

This doesn't provide functional enterprise support (e.g., for https://github.com/mozilla-releng/simple-github/issues/196), but supports continuing operation for repos and orgs.