### PR TITLE
chore: version bump 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.2.0 (2026-08-04)
+
+### Feat
+
+- Provide convenience `get_token` method (#189)
+
+### Fix
+
+- Don't fail on missing `login` in app installation details (#197)
+- Stop declaring support for Python 3.9, which was dropped in 3.0 (#175)
+- app_id can be a str (#146)
+
 ## 3.1.0 (2026-03-10)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "simple-github"
 description = "A simple Github client that only provides auth and access to the REST and GraphQL APIs."
-version = "3.1.0"
+version = "3.2.0"
 authors = [
   { name = "Mozilla Release Engineering", email =  "release+simple-github@mozilla.com"}
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1641,7 +1641,7 @@ wheels = [
 
 [[package]]
 name = "simple-github"
-version = "3.1.0"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", extra = ["speedups"] },


### PR DESCRIPTION
Arguably this could be 4.0.0 because we didn't deprecate python 3.9 properly in 3.0? I could go either way.